### PR TITLE
Sample app - rendering more chat events

### DIFF
--- a/Example/BPMobileMessaging/ChatViewModel.swift
+++ b/Example/BPMobileMessaging/ChatViewModel.swift
@@ -250,10 +250,6 @@ extension ChatViewModel {
             switch eventsResult {
             case .success(let sessions):
                 print("Received case history: \(sessions)")
-                DispatchQueue.main.async {
-//                    self?.currentChatID = chatID
-//                    self?.processSessionEvents(chatID: chatID, events: events)
-                }
             case .failure(let error):
                 print("Failed to getCaseHistory: \(error)")
             }

--- a/Example/BPMobileMessaging/ChatViewModel.swift
+++ b/Example/BPMobileMessaging/ChatViewModel.swift
@@ -63,11 +63,7 @@ class ChatViewModel {
     }
     
     func getParty(partyID: String) -> ChatUser {
-        var party = self.parties[partyID]
-        if party == nil {
-            return ChatUser(senderId: "", displayName: "")
-        }
-        return party!
+       parties[partyID] ?? ChatUser(senderId: "", displayName: "")
     }
 
     func chatMessagesCount() -> Int {

--- a/Example/BPMobileMessaging/ChatViewModel.swift
+++ b/Example/BPMobileMessaging/ChatViewModel.swift
@@ -14,6 +14,9 @@ class ChatViewModel {
     private let service: ServiceDependencyProtocol
     var sectionsCount: Int = 1
     let currentChatID: String?
+    private var systemParty = ChatUser(senderId: "", displayName: "")
+    private var myParty = ChatUser(senderId: "", displayName: "Me")
+    private var parties: [String: ChatUser] = [:]
     private var messages: [ChatMessage] {
         didSet {
             delegate?.update()
@@ -21,7 +24,7 @@ class ChatViewModel {
     }
     weak var delegate: ChatViewModelUpdatable?
     var currentSender: SenderType {
-        ChatUser(senderId: "", displayName: "")
+        myParty
     }
     var messagesEmpty: Bool {
         messages.count == 0
@@ -36,12 +39,35 @@ class ChatViewModel {
     init(service: ServiceDependencyProtocol, currentChatID: String) {
         self.service = service
         self.currentChatID = currentChatID
+        //  My party ID is the same as the chat ID
+        self.myParty = ChatUser(senderId: currentChatID, displayName: "Me")
+        self.parties[myParty.senderId] = myParty
         self.messages = []
+        
         NotificationCenter.default.addObserver(self, selector: #selector(receivedEvents), name: NotificationName.contactCenterEventsReceived.name, object: nil)
-    }
+
+        self.subscribeForNotifications() { subscribeResult in
+            DispatchQueue.main.async {
+                switch subscribeResult {
+                case .success:
+                    print("Subscribe for remote notifications confirmed")
+                case .failure(let error):
+                    print("Failed to subscribe for notifications: \(error)")
+                }
+            }
+        }
+   }
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+    }
+    
+    func getParty(partyID: String) -> ChatUser {
+        var party = self.parties[partyID]
+        if party == nil {
+            return ChatUser(senderId: "", displayName: "")
+        }
+        return party!
     }
 
     func chatMessagesCount() -> Int {
@@ -58,9 +84,8 @@ class ChatViewModel {
         }
         var messages = [ChatMessage]()
         data.forEach { component in
-            let user = ChatUser(senderId: "", displayName: "")
             if let str = component as? String {
-                messages.append(ChatMessage(text: str, user: user, messageId: UUID().uuidString, date: Date()))
+                messages.append(ChatMessage(text: str, user: myParty, messageId: UUID().uuidString, date: Date()))
             }
         }
 
@@ -100,41 +125,104 @@ extension ChatViewModel {
         processSessionEvents(events: events)
     }
 
+    private func subscribeForNotifications(completion: @escaping (Result<Void, Error>) -> Void) {
+        
+        guard let chatID = self.currentChatID else {
+            print("Chat ID is not set")
+            completion(.failure(ExampleAppError.chatIdNotSet))
+            return
+        }
+        
+        guard let deviceToken = service.deviceToken else {
+            print("Device token is not set")
+            completion(.failure(ExampleAppError.deviceTokenNotSet))
+            return
+        }
+
+        if service.useFirebase {
+            service.contactCenterService.subscribeForRemoteNotificationsFirebase(chatID: chatID,
+                                                                         deviceToken: deviceToken,
+                                                                         with: completion)
+        } else {
+            service.contactCenterService.subscribeForRemoteNotificationsAPNs(chatID: chatID,
+                                                                     deviceToken: deviceToken,
+                                                                     with: completion)
+        }
+    }
+
     private func processSessionEvents(events: [ContactCenterEvent]) {
         for e in events {
+            guard let chatID = self.currentChatID else {
+                print("chatID is empty")
+                continue
+            }
+
             switch e {
+            case .chatSessionPartyJoined(let partyID, let firstName, let lastName, let displayName, let type, let timestamp):
+                print("\(timestamp): party: \(partyID) joined: \(firstName), \(lastName), \(displayName)")
+                let chatUser = ChatUser(senderId: partyID, displayName: displayName ?? ((firstName ?? "") + " " + (lastName ?? "")))
+                self.parties[partyID] = chatUser
+                messages.append(ChatMessage(text: "Joined the session",
+                                            user: chatUser,
+                                            messageId: "",
+                                            date: timestamp))
+            case .chatSessionPartyLeft(let partyID, let timestamp):
+                print("\(timestamp): party: \(partyID) left")
+                messages.append(ChatMessage(text: "Left the session",
+                                            user: self.getParty(partyID: partyID),
+                                            messageId: "",
+                                            date: timestamp))
             case .chatSessionMessage(let messageID, let partyID, let message, let timestamp):
                 print("\(timestamp): message: \(message) from party \(partyID)")
-                guard let chatID = self.currentChatID else {
-                    print("chatID is empty")
-                    continue
-                }
                 guard let partyID = partyID, let timestamp = timestamp else {
                     print("partyID or timestamp empty")
                     return
                 }
-                let chatUser = ChatUser(senderId: partyID, displayName: "")
                 messages.append(ChatMessage(text: message,
-                                            user: chatUser,
+                                            user: self.getParty(partyID: partyID),
                                             messageId: messageID,
                                             date: timestamp))
                 chatMessageDelivered(chatID: chatID, messageID: messageID)
                 chatMessageRead(chatID: chatID, messageID: messageID)
             case .chatSessionStatus(let state, let estimatedWaitTime):
                 if state == .connected {
-                    guard let chatID = self.currentChatID else {
-                        print("chatID is empty")
-                        continue
-                    }
                     print("Connected to a chat: \(chatID)")
                 } else {
-                    guard let chatID = self.currentChatID else {
-                        print("chatID is empty")
-                        continue
-                    }
                     print("Waiting in a queue: \(chatID) estimated wait time: \(estimatedWaitTime)")
                 }
+            case .chatSessionCaseSet(let caseID, let timestamp):
+                self.getCaseHistory(chatID: chatID)
+            case .chatSessionTimeoutWarning(let message, let timestamp):
+                messages.append(ChatMessage(text: message,
+                                            user: self.systemParty,
+                                            messageId: "",
+                                            date: timestamp))
+            case .chatSessionInactivityTimeout(let message, let timestamp):
+                messages.append(ChatMessage(text: message,
+                                            user: self.systemParty,
+                                            messageId: "",
+                                            date: timestamp))
+            case .chatSessionEnded:
+                messages.append(ChatMessage(text: "The session has ended",
+                                            user: self.systemParty,
+                                            messageId: "",
+                                            date: Date()))
+//                self.closeCase(chatID: chatID)
             default:()
+            }
+        }
+    }
+
+    private func getChatHistory(chatID: String) {
+        service.contactCenterService.getChatHistory(chatID: chatID) { [weak self] eventsResult in
+            DispatchQueue.main.async {
+                switch eventsResult {
+                case .success(let events):
+                    print("Received chat history")
+                        self?.processSessionEvents(events: events)
+                case .failure(let error):
+                    print("Failed to getChatHistory: \(error)")
+                }
             }
         }
     }
@@ -157,6 +245,67 @@ extension ChatViewModel {
                 print("chatMessageRead confirmed")
             case .failure(let error):
                 print("chatMessageRead error: \(error)")
+            }
+        }
+    }
+    
+    private func getCaseHistory(chatID: String) {
+        service.contactCenterService.getCaseHistory(chatID: chatID) { [weak self] eventsResult in
+            switch eventsResult {
+            case .success(let sessions):
+                print("Received case history: \(sessions)")
+                DispatchQueue.main.async {
+//                    self?.currentChatID = chatID
+//                    self?.processSessionEvents(chatID: chatID, events: events)
+                }
+            case .failure(let error):
+                print("Failed to getCaseHistory: \(error)")
+            }
+        }
+    }
+
+    private func closeCase(chatID: String) {
+        service.contactCenterService.closeCase(chatID: chatID) { result in
+            switch result {
+            case .success(_):
+                print("closeCase confirmed")
+            case .failure(let error):
+                print("closeCase error: \(error)")
+            }
+        }
+    }
+
+    private func sendChatMessage(chatID: String, message: String) {
+        service.contactCenterService.sendChatMessage(chatID: chatID, message: "Hello") { chatMessageResult in
+            switch chatMessageResult {
+            case .success(let messageID):
+                print("MessageID: \(messageID)")
+
+            case .failure(let error):
+
+                print("Failed to send chat message: \(error)")
+            }
+        }
+    }
+
+    private func disconnectChat(chatID: String) {
+        service.contactCenterService.disconnectChat(chatID: chatID) { result in
+            switch result {
+            case .success(_):
+                print("disconnectChat confirmed")
+            case .failure(let error):
+                print("disconnectChat error: \(error)")
+            }
+        }
+    }
+
+    private func endChat(chatID: String) {
+        service.contactCenterService.endChat(chatID: chatID) { result in
+            switch result {
+            case .success(_):
+                print("endChat confirmed")
+            case .failure(let error):
+                print("endChat error: \(error)")
             }
         }
     }

--- a/Example/BPMobileMessaging/ExampleAppError.swift
+++ b/Example/BPMobileMessaging/ExampleAppError.swift
@@ -5,4 +5,5 @@ import Foundation
 
 enum ExampleAppError: Error {
     case deviceTokenNotSet
+    case chatIdNotSet
 }

--- a/Example/BPMobileMessaging/HelpRequestViewModel.swift
+++ b/Example/BPMobileMessaging/HelpRequestViewModel.swift
@@ -29,12 +29,10 @@ class HelpRequestViewModel {
     init(service: ServiceDependencyProtocol) {
         self.service = service
 
-        NotificationCenter.default.addObserver(self, selector: #selector(receivedEvents), name: NotificationName.contactCenterEventsReceived.name, object: nil)
         checkChatAvailability()
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
     }
 
     func helpMePressed() {
@@ -46,16 +44,7 @@ class HelpRequestViewModel {
             print("chatID is empty")
             return
         }
-        getChatHistory(chatID: chatID)
-    }
-
-    @objc
-    private func receivedEvents(notification: Notification) {
-        guard let events = notification.userInfo?[NotificationUserInfoKey.contactCenterEvents] as? [ContactCenterEvent] else {
-            print("Failed to get contact center events: \(notification)")
-            return
-        }
-        processSessionEvents(events: events)
+//        getChatHistory(chatID: chatID)
     }
 }
 
@@ -77,190 +66,17 @@ extension HelpRequestViewModel {
     }
     private func requestChat() {
         isRequestInProgress = true
-        service.contactCenterService.requestChat(phoneNumber: "12345", from: "54321", parameters: [:]) { [weak self] chatPropertiesResult in
+        service.contactCenterService.requestChat(phoneNumber: "12345", from: "54321", parameters: ["email":"mobilecustomer@example.com"]) { [weak self] chatPropertiesResult in
             DispatchQueue.main.async {
                 self?.isRequestInProgress = false
                 switch chatPropertiesResult {
                 case .success(let chatProperties):
                     print("Chat properties: \(chatProperties)")
                     self?.currentChatID = chatProperties.chatID
-                    self?.subscribeForNotifications(chatID: chatProperties.chatID) { subscribeResult in
-                        DispatchQueue.main.async {
-                            switch subscribeResult {
-                            case .success:
-                                print("Subscribe for remote notifications confirmed")
-                            case .failure(let error):
-                                print("Failed to subscribe for notifications: \(error)")
-                            }
-                        }
-                    }
+                    self?.delegate?.showChat()
                 case .failure(let error):
                     print("\(error)")
                 }
-            }
-        }
-    }
-
-    private func getChatHistory(chatID: String) {
-        isRequestInProgress = true
-        service.contactCenterService.getChatHistory(chatID: chatID) { [weak self] eventsResult in
-            DispatchQueue.main.async {
-                self?.isRequestInProgress = false
-                switch eventsResult {
-                case .success(let events):
-                    print("Received chat history")
-                        self?.currentChatID = chatID
-                        self?.processSessionEvents(events: events)
-                case .failure(let error):
-                    print("Failed to getChatHistory: \(error)")
-                }
-            }
-        }
-    }
-
-    private func getCaseHistory(chatID: String) {
-        service.contactCenterService.getCaseHistory(chatID: chatID) { [weak self] eventsResult in
-            switch eventsResult {
-            case .success(let sessions):
-                print("Received case history: \(sessions)")
-                DispatchQueue.main.async {
-//                    self?.currentChatID = chatID
-//                    self?.processSessionEvents(chatID: chatID, events: events)
-                }
-            case .failure(let error):
-                print("Failed to getCaseHistory: \(error)")
-            }
-        }
-    }
-
-    private func endChatSession(chatID: String) {
-        self.disconnectChat(chatID: chatID)
-        self.endChat(chatID: chatID)
-    }
-
-    private func subscribeForNotifications(chatID: String, completion: @escaping (Result<Void, Error>) -> Void) {
-        guard let deviceToken = service.deviceToken else {
-            print("Device token is not set")
-            completion(.failure(ExampleAppError.deviceTokenNotSet))
-            return
-        }
-
-        if service.useFirebase {
-            service.contactCenterService.subscribeForRemoteNotificationsFirebase(chatID: chatID,
-                                                                         deviceToken: deviceToken,
-                                                                         with: completion)
-        } else {
-            service.contactCenterService.subscribeForRemoteNotificationsAPNs(chatID: chatID,
-                                                                     deviceToken: deviceToken,
-                                                                     with: completion)
-        }
-    }
-
-    private func sendChatMessage(chatID: String, message: String) {
-        service.contactCenterService.sendChatMessage(chatID: chatID, message: "Hello") { chatMessageResult in
-            switch chatMessageResult {
-            case .success(let messageID):
-                print("MessageID: \(messageID)")
-
-            case .failure(let error):
-
-                print("Failed to send chat message: \(error)")
-            }
-        }
-    }
-
-    private func chatMessageDelivered(chatID: String, messageID: String) {
-        service.contactCenterService.chatMessageDelivered(chatID: chatID, messageID: messageID) { result in
-            switch result {
-            case .success(_):
-                print("chatMessageDelivered confirmed")
-            case .failure(let error):
-                print("chatMessageDelivered error: \(error)")
-            }
-        }
-    }
-
-    private func chatMessageRead(chatID: String, messageID: String) {
-        service.contactCenterService.chatMessageRead(chatID: chatID, messageID: messageID) { result in
-            switch result {
-            case .success(_):
-                print("chatMessageRead confirmed")
-            case .failure(let error):
-                print("chatMessageRead error: \(error)")
-            }
-        }
-    }
-
-    private func disconnectChat(chatID: String) {
-        service.contactCenterService.disconnectChat(chatID: chatID) { result in
-            switch result {
-            case .success(_):
-                print("disconnectChat confirmed")
-            case .failure(let error):
-                print("disconnectChat error: \(error)")
-            }
-        }
-    }
-
-    private func endChat(chatID: String) {
-        service.contactCenterService.endChat(chatID: chatID) { result in
-            switch result {
-            case .success(_):
-                print("endChat confirmed")
-            case .failure(let error):
-                print("endChat error: \(error)")
-            }
-        }
-    }
-
-    private func closeCase(chatID: String) {
-        service.contactCenterService.closeCase(chatID: chatID) { result in
-            switch result {
-            case .success(_):
-                print("closeCase confirmed")
-            case .failure(let error):
-                print("closeCase error: \(error)")
-            }
-        }
-    }
-
-    private func processSessionEvents(events: [ContactCenterEvent]) {
-        for e in events {
-            switch e {
-            case .chatSessionMessage(let messageID, let partyID, let message, let timestamp):
-                print("\(timestamp): message: \(message) from party \(partyID)")
-                guard let chatID = self.currentChatID else {
-                    print("chatID is empty")
-                    continue
-                }
-                self.chatMessageDelivered(chatID: chatID, messageID: messageID)
-                self.chatMessageRead(chatID: chatID, messageID: messageID)
-            case .chatSessionStatus(let state, let estimatedWaitTime):
-                if state == .connected {
-                    self.delegate?.showChat()
-                    guard let chatID = self.currentChatID else {
-                        print("chatID is empty")
-                        continue
-                    }
-                    print("Connected to a chat: \(chatID)")
-                } else if state == .queued {
-                    guard let chatID = self.currentChatID else {
-                        print("chatID is empty")
-                        continue
-                    }
-                    print("Waiting in a queue: \(chatID) estimated wait time: \(estimatedWaitTime)")
-                }
-            case .chatSessionCaseSet(let caseID, let timestamp):
-                guard let chatID = self.currentChatID else {
-                    return
-                }
-                self.getCaseHistory(chatID: chatID)
-            case .chatSessionPartyLeft(let partyID, let timestamp):
-                guard let chatID = self.currentChatID else {
-                    return
-                }
-                self.closeCase(chatID: chatID)
-            default:()
             }
         }
     }


### PR DESCRIPTION
1. Switch from help request to chat view immediately on chat creation
2. Move all session related functionality from HelpRequest model to ChatView model
3. Render party joined/left, timeout warning and inactivity timeout events
4. Cache joined parties and render party name with each message