### PR TITLE
Fix/sample app push notifications fix

### DIFF
--- a/Example/BPMobileMessaging.xcodeproj/project.pbxproj
+++ b/Example/BPMobileMessaging.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* ContactCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* ContactCenterTests.swift */; };
 		8729710E0FD0DD6FBE468D0A /* Pods_BPMobileMessaging_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3AD6BBEF622A29C4CFDE65D /* Pods_BPMobileMessaging_Tests.framework */; };
+		8E72CCF3261563EA00A44587 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8E72CCF1261563EA00A44587 /* Localizable.strings */; };
 		A81B471DE62BDFC3937D2F4C /* Pods_BPMobileMessaging_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BFB77F350367830558C3DA9 /* Pods_BPMobileMessaging_Example.framework */; };
 		F10126A025E6F74500AC0B5D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F101268E25E6EEE100AC0B5D /* GoogleService-Info.plist */; };
 		F10126F925E82F3600AC0B5D /* ViewController+ServiceDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10126F825E82F3600AC0B5D /* ViewController+ServiceDependency.swift */; };
@@ -63,6 +64,8 @@
 		607FACEB1AFB9204008FA782 /* ContactCenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCenterTests.swift; sourceTree = "<group>"; };
 		715D3021182EAF5BBF64ABEB /* Pods-BPMobileMessaging_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BPMobileMessaging_Tests.release.xcconfig"; path = "Target Support Files/Pods-BPMobileMessaging_Tests/Pods-BPMobileMessaging_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		81D2A75A9B91F57A53F2E4AF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		8E72CCF2261563EA00A44587 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		8E72CCF6261563FF00A44587 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A3AD6BBEF622A29C4CFDE65D /* Pods_BPMobileMessaging_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BPMobileMessaging_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F101258325E464FD00AC0B5D /* BPMobileMessaging_Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BPMobileMessaging_Example.entitlements; sourceTree = "<group>"; };
 		F101268E25E6EEE100AC0B5D /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -151,6 +154,7 @@
 		607FACD21AFB9204008FA782 /* Example for BPMobileMessaging */ = {
 			isa = PBXGroup;
 			children = (
+				8E72CCF1261563EA00A44587 /* Localizable.strings */,
 				F101272625E863ED00AC0B5D /* NotificationNamesKeys.swift */,
 				F10126FC25E82FA900AC0B5D /* Extensions */,
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
@@ -326,8 +330,8 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				English,
-				en,
 				Base,
+				ru,
 			);
 			mainGroup = 607FACC71AFB9204008FA782;
 			productRefGroup = 607FACD11AFB9204008FA782 /* Products */;
@@ -346,6 +350,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
+				8E72CCF3261563EA00A44587 /* Localizable.strings in Resources */,
 				F10126A025E6F74500AC0B5D /* GoogleService-Info.plist in Resources */,
 				F19B0C4325FE6E9200799CAA /* Settings.bundle in Resources */,
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
@@ -510,6 +515,15 @@
 			name = LaunchScreen.xib;
 			sourceTree = "<group>";
 		};
+		8E72CCF1261563EA00A44587 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				8E72CCF2261563EA00A44587 /* Base */,
+				8E72CCF6261563FF00A44587 /* ru */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
@@ -517,6 +531,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -571,6 +586,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/Example/BPMobileMessaging/AppDelegate.swift
+++ b/Example/BPMobileMessaging/AppDelegate.swift
@@ -139,14 +139,19 @@ extension AppDelegate {
         }
 
         let preferences = settings["PreferenceSpecifiers"] as! NSArray
-        var defaultsToRegister = [String: AnyObject]()
+        var defaultsToRegister = [String: Any]()
         for prefSpecification in preferences {
-            if let post = prefSpecification as? [String: AnyObject] {
-                guard let key = post["Key"] as? String,
-                    let defaultValue = post["DefaultValue"] else {
+            if let spec = prefSpecification as? [String: Any] {
+                guard let key = spec["Key"] as? String,
+                    let defaultValue = spec["DefaultValue"] else {
                         continue
                 }
-                defaultsToRegister[key] = defaultValue
+                if let type = spec["Type"] as? String,
+                   type == "PSToggleSwitchSpecifier" {
+                    defaultsToRegister[key] = (defaultValue as? String) == "YES" ? true: false
+                } else {
+                    defaultsToRegister[key] = defaultValue
+                }
             }
         }
         UserDefaults.standard.register(defaults: defaultsToRegister)

--- a/Example/BPMobileMessaging/AppDelegate.swift
+++ b/Example/BPMobileMessaging/AppDelegate.swift
@@ -31,13 +31,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var appID: String? {
         value(for: \AppDelegate.appID)
     }
+    var useFirebase: Bool? {
+        value(for: \AppDelegate.useFirebase)
+    }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
         self.window = UIWindow(frame: UIScreen.main.bounds)
         registerDefaultsFromSettingsBundle()
 
-        guard let baseURL = baseURL, let tenantURL = tenantURL, let appID = appID else {
+        guard let baseURL = baseURL, let tenantURL = tenantURL, let appID = appID, let useFirebase = useFirebase else {
 
             let alert = UIAlertController(title: "Error",
                                           message:"You need to provide baseURL, tenantURL and appID to start the app. After pressing OK button you will be switched to Settings.",
@@ -54,7 +57,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return true
         }
 
-        self.service = ServiceManager(baseURL: baseURL, tenantURL: tenantURL, appID: appID)
+        self.service = ServiceManager(baseURL: baseURL, tenantURL: tenantURL, appID: appID, useFirebase: useFirebase)
 
         let storyboard = UIStoryboard.init(name: "Main", bundle: nil)
         guard let helpRequestViewController = storyboard.instantiateViewController(withIdentifier: "HelpRequestViewController") as? HelpRequestViewController else {

--- a/Example/BPMobileMessaging/Base.lproj/Localizable.strings
+++ b/Example/BPMobileMessaging/Base.lproj/Localizable.strings
@@ -8,3 +8,6 @@
 
 "keyChatNewMessageTitle"="New chat message";
 "keyChatNewMessageSubtitle"="From %@ %@";
+
+"keyChatNewFileTitle"="New chat file";
+"keyChatNewFileSubtitle"="From %@ %@";

--- a/Example/BPMobileMessaging/Base.lproj/Localizable.strings
+++ b/Example/BPMobileMessaging/Base.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+/* 
+  Localizable.strings
+  BPMobileMessaging
+
+  Created by Alexander Lobastov on 3/31/21.
+  Copyright © 2021 BrightPattern. All rights reserved.
+*/
+
+"keyChatNewMessageTitle"="New chat message";
+"keyChatNewMessageSubtitle"="From %@ %@";

--- a/Example/BPMobileMessaging/ContactCenterService.swift
+++ b/Example/BPMobileMessaging/ContactCenterService.swift
@@ -12,14 +12,16 @@ final class ServiceManager: NSObject, ServiceDependencyProtocol {
     let baseURL: URL
     let tenantURL: URL
     let appID: String
+    let useFirebase: Bool
     lazy var contactCenterService: ContactCenterCommunicating = {
         ContactCenterCommunicator(baseURL: baseURL, tenantURL: tenantURL, appID: appID, clientID: clientID)
     }()
-
-    init(baseURL: URL, tenantURL: URL, appID: String) {
+    
+    init(baseURL: URL, tenantURL: URL, appID: String, useFirebase: Bool) {
         self.baseURL = baseURL
         self.tenantURL = tenantURL
         self.appID = appID
+        self.useFirebase = useFirebase
 
         super.init()
 
@@ -120,8 +122,5 @@ extension ServiceManager {
     }
     var phoneNumber: String {
         value(for: \ServiceManager.phoneNumber) ?? ""
-    }
-    var useFirebase: Bool {
-        value(for: \ServiceManager.useFirebase) ?? true
     }
 }

--- a/Example/BPMobileMessaging/HelpRequestViewController.swift
+++ b/Example/BPMobileMessaging/HelpRequestViewController.swift
@@ -49,9 +49,6 @@ class HelpRequestViewController: ViewController, ServiceDependencyProviding {
         backgroundImage.isUserInteractionEnabled = true
         backgroundImage.addGestureRecognizer(tapGesture)
         problemDescription.backgroundColor = .white
-//        textView.attributedPlaceholder = NSAttributedString(string: "Type your message here",
-//                                                            attributes: [NSAttributedStringKey.font: textView.font,
-//                                                                         NSAttributedStringKey.foregroundColor: UIColor.lightGray])
     }
 
     private func setupSubscriptions() {

--- a/Example/BPMobileMessaging/HelpRequestViewController.swift
+++ b/Example/BPMobileMessaging/HelpRequestViewController.swift
@@ -11,7 +11,6 @@ import UIKit
 class HelpRequestViewController: ViewController, ServiceDependencyProviding {
     var service: ServiceDependencyProtocol?
     var bundleIdentifier: String = Bundle.main.bundleIdentifier ?? ""
-    @IBOutlet weak var pastConversationsBottomConstraint: NSLayoutConstraint!
     @IBOutlet weak var problemDescription: UITextView!
     @IBOutlet weak var helpMeButton: UIButton!
     @IBOutlet weak var caseNumber: UITextField!
@@ -89,9 +88,7 @@ class HelpRequestViewController: ViewController, ServiceDependencyProviding {
         // get a rect for the textView frame
         let containerFrame = problemDescription.frame
         let diff = keyboardBounds.origin.y - containerFrame.maxY
-        if diff < 10 {
-            self.pastConversationsBottomConstraint.constant += 10 - diff
-        }
+
         UIView.beginAnimations(nil, context: nil)
         UIView.setAnimationBeginsFromCurrentState(true)
         UIView.setAnimationDuration(duration.doubleValue)
@@ -101,7 +98,6 @@ class HelpRequestViewController: ViewController, ServiceDependencyProviding {
     }
 
     private func resetBottomSpace() {
-//        pastConversationsBottomConstraint.constant = viewModel.bottomSpace
     }
 
     @objc

--- a/Example/BPMobileMessaging/PartialKeyPath+Extension.swift
+++ b/Example/BPMobileMessaging/PartialKeyPath+Extension.swift
@@ -8,7 +8,6 @@ extension PartialKeyPath where Root == ServiceManager {
     var stringValue: String {
         switch self {
         case \ServiceManager.clientID: return "clientID"
-        case \ServiceManager.useFirebase: return "useFirebase"
         case \ServiceManager.firstName: return "firstName"
         case \ServiceManager.lastName: return "lastName"
         case \ServiceManager.phoneNumber: return "phoneNumber"
@@ -23,6 +22,7 @@ extension PartialKeyPath where Root == AppDelegate {
         case \AppDelegate.baseURL: return "baseURL"
         case \AppDelegate.tenantURL: return "tenantURL"
         case \AppDelegate.appID: return "appID"
+        case \AppDelegate.useFirebase: return "useFirebase"
         default: fatalError("Unexpected keyPath")
         }
     }

--- a/Example/BPMobileMessaging/ru.lproj/LaunchScreen.strings
+++ b/Example/BPMobileMessaging/ru.lproj/LaunchScreen.strings
@@ -1,0 +1,6 @@
+
+/* Class = "UILabel"; text = "  Copyright © 2021 BrightPattern. All rights reserved."; ObjectID = "8ie-xW-0ye"; */
+"8ie-xW-0ye.text" = "  Copyright © 2021 BrightPattern. All rights reserved.";
+
+/* Class = "UILabel"; text = "BPMobileMessaging"; ObjectID = "kId-c2-rCX"; */
+"kId-c2-rCX.text" = "BPMobileMessaging";

--- a/Example/BPMobileMessaging/ru.lproj/Localizable.strings
+++ b/Example/BPMobileMessaging/ru.lproj/Localizable.strings
@@ -8,3 +8,6 @@
 
 "keyChatNewMessageTitle"="Новое сообщение";
 "keyChatNewMessageSubtitle"="От %@ %@";
+
+"keyChatNewFileTitle"="Новый файл";
+"keyChatNewFileSubtitle"="От %@ %@";

--- a/Example/BPMobileMessaging/ru.lproj/Localizable.strings
+++ b/Example/BPMobileMessaging/ru.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+/* 
+  Localizable.strings
+  BPMobileMessaging
+
+  Created by Alexander Lobastov on 3/31/21.
+  Copyright © 2021 BrightPattern. All rights reserved.
+*/
+
+"keyChatNewMessageTitle"="Новое сообщение";
+"keyChatNewMessageSubtitle"="От %@ %@";

--- a/Example/BPMobileMessaging/ru.lproj/Main.strings
+++ b/Example/BPMobileMessaging/ru.lproj/Main.strings
@@ -1,0 +1,9 @@
+
+/* Class = "UIButton"; normalTitle = "Help me"; ObjectID = "Abn-8Y-zcD"; */
+"Abn-8Y-zcD.normalTitle" = "Help me";
+
+/* Class = "UILabel"; text = "Case number:"; ObjectID = "fHQ-wP-YDm"; */
+"fHQ-wP-YDm.text" = "Case number:";
+
+/* Class = "UILabel"; text = "Problem description:"; ObjectID = "qQC-ra-Swn"; */
+"qQC-ra-Swn.text" = "Problem description:";


### PR DESCRIPTION
Fixes Use Firebase configuration selector.
Adds localized title/subtitle for new chat message and new chat file push notifications.
Fixes crash when requesting new chat (only happened on physical iPhone device; not on simulator).